### PR TITLE
Cu 8acmyp agregar elemento documentation en el modelador

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,21 +85,21 @@ export const elementClassesToRemove = [
 // Item classes to remove from the item lateral pad
 
 export const padEntriesToRemove: PadEntriesToRemoveType = {
-  StartEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  IntermediateThrowEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  IntermediateCatchEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  EndEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  CallActivity: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  SubProcess: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Gateway: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  SequenceFlow: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  TextAnnotation: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Participant: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Lane: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  DataStoreReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  DataObjectReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  label: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Association: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  StartEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  IntermediateThrowEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  IntermediateCatchEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  EndEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  CallActivity: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  SubProcess: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Gateway: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  SequenceFlow: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  TextAnnotation: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Participant: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Lane: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  DataStoreReference: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  DataObjectReference: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  label: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Association: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
   Task: []
 }
 
@@ -117,13 +117,15 @@ const App: FC = () => {
         padEntriesToRemove={padEntriesToRemove}
         onElementChange={(xml: string): void => alert(xml)}
         onTaskTarget={(event: CustomEvent): void => alert(JSON.stringify(event.detail))}
-        onTaskLabelTarget={(event: CustomEvent): void => {
-        // Set an element programmatically
-        const modeling = modelerRef?.current?.get('modeling')
-        const elementRegistry = modelerRef?.current?.get('elementRegistry')
-        const element = elementRegistry.get(event.detail.id)
-        modeling.updateProperties(element, { name: 'Example task label' })
-      }}
+        onTaskDocumentationTarget={(event: CustomEvent): void => {
+          // Create an element programmatically
+          const elementRegistry = modelerRef?.current?.get('elementRegistry')
+          const modeling = modelerRef?.current?.get('modeling')
+          const moddle = modelerRef?.current?.get('moddle')
+          const element = elementRegistry.get(event.detail.id)
+          const documentation = moddle.create('bpmn:Documentation', { text: 'Documenation text' })
+          modeling.updateProperties(element, { documentation: [documentation] })
+        }}
         onError={(error: Error): void => alert(error)}
       />
     ),
@@ -211,21 +213,21 @@ export const elementClassesToRemove = [
 ]
 
 export const padEntriesToRemove = {
-  StartEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  IntermediateThrowEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  IntermediateCatchEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  EndEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  CallActivity: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  SubProcess: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Gateway: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  SequenceFlow: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  TextAnnotation: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Participant: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Lane: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  DataStoreReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  DataObjectReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  label: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Association: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  StartEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  IntermediateThrowEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  IntermediateCatchEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  EndEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  CallActivity: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  SubProcess: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Gateway: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  SequenceFlow: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  TextAnnotation: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Participant: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Lane: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  DataStoreReference: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  DataObjectReference: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  label: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Association: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
   Task: []
 }
 
@@ -243,13 +245,15 @@ const App = () => {
         padEntriesToRemove={padEntriesToRemove}
         onElementChange={xml => alert(xml)}
         onTaskTarget={event => alert(JSON.stringify(event.detail))}
-        onTaskLabelTarget={event => {
-        // Set an element programmatically
-        const modeling = modelerRef?.current?.get('modeling')
-        const elementRegistry = modelerRef?.current?.get('elementRegistry')
-        const element = elementRegistry.get(event.detail.id)
-        modeling.updateProperties(element, { name: 'Example task label' })
-      }}
+        onTaskDocumentationTarget={event => {
+          // Create an element programmatically
+          const elementRegistry = modelerRef?.current?.get('elementRegistry')
+          const modeling = modelerRef?.current?.get('modeling')
+          const moddle = modelerRef?.current?.get('moddle')
+          const element = elementRegistry.get(event.detail.id)
+          const documentation = moddle.create('bpmn:Documentation', { text: 'Documenation text' })
+          modeling.updateProperties(element, { documentation: [documentation] })
+        }}
         onError={error => alert(error)}
       />
     ),
@@ -306,7 +310,7 @@ export default App
   }
 ```
 
-* **onTaskLabelTarget:** It is a function that is executed when you click on the document icon in the side pad of a task element, it accepts a function that receives as event parameter of the selected element. **\***
+* **onTaskDocumentationTarget:** It is a function that is executed when you click on the document icon in the side pad of a task element, it accepts a function that receives as event parameter of the selected element. **\***
 
 *event.detail* returns
 

--- a/README.md
+++ b/README.md
@@ -22,69 +22,255 @@ With React Typescript
 
 ```tsx
 import React, { FC, useRef, MutableRefObject, Fragment } from 'react'
-import { Bpmn, BpmnModelerType } from '@arkondata/react-bpmn-modeler/lib/components'
+import { Bpmn } from '@arkondata/react-bpmn-modeler/lib/components'
+import { BpmnModelerType, PadEntriesToRemoveType } from '@arkondata/react-bpmn-modeler/lib/components/types'
+
+//load bpmnStringFile from anywere
+const getBpmnFile = (): string => `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  id="Definitions_1"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+>
+  <bpmn:collaboration id="Collaboration_0nai2jf">
+    <bpmn:participant id="Participant_0n01i1w" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="Event_0sd8xgt" name="Start">
+      <bpmn:outgoing>Flow_094auwy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_02384jl" name="Example task label">
+      <bpmn:incoming>Flow_094auwy</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_094auwy" sourceRef="Event_0sd8xgt" targetRef="Activity_02384jl" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0nai2jf">
+      <bpmndi:BPMNShape id="Participant_0n01i1w_di" bpmnElement="Participant_0n01i1w" isHorizontal="true">
+        <dc:Bounds x="-400" y="-320" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_094auwy_di" bpmnElement="Flow_094auwy">
+        <di:waypoint x="-282" y="-210" />
+        <di:waypoint x="-230" y="-210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0sd8xgt_di" bpmnElement="Event_0sd8xgt">
+        <dc:Bounds x="-318" y="-228" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-312" y="-185" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02384jl_di" bpmnElement="Activity_02384jl">
+        <dc:Bounds x="-230" y="-250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`
+
+// Item classes to remove from the item popup panel
+export const elementClassesToRemove = [
+  'bpmn-icon-subprocess-collapsed',
+  'bpmn-icon-subprocess-expanded',
+  'bpmn-icon-business-rule',
+  'bpmn-icon-service',
+  'bpmn-icon-start-event-condition',
+  'bpmn-icon-start-event-signal',
+  'bpmn-icon-data-object',
+  'bpmn-icon-data-store',
+]
+
+// Item classes to remove from the item lateral pad
+
+export const padEntriesToRemove: PadEntriesToRemoveType = {
+  StartEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  IntermediateThrowEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  IntermediateCatchEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  EndEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  CallActivity: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  SubProcess: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Gateway: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  SequenceFlow: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  TextAnnotation: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Participant: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Lane: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  DataStoreReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  DataObjectReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  label: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Association: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Task: []
+}
 
 const App: FC = () => {
-  const modelerRef: MutableRefObject<BpmnModelerType | undefined> = useRef()
-  const bpmnModelerRef: MutableRefObject<JSX.Element> = useRef(
-    <Bpmn
-      modelerRef={modelerRef}
-      bpmnStringFile={''}
-      modelerInnerHeight={window.innerHeight}
-      onElementChange={(xml: string): void => alert(xml)}
-      onTaskTarget={(event: CustomEvent): void => alert(JSON.stringify(event.detail))}
-      onTaskLabelTarget={(event: CustomEvent): void => {
+  const modelerRef = useRef<BpmnModelerType>()
+  const [model, setModel] = useState<JSX.Element>()
+  const [bpmnStringFile, setBpmnStringFile] = useState('')
+  const setModeler = useCallback(
+    (): JSX.Element => (
+      <Bpmn
+        modelerRef={modelerRef}
+        bpmnStringFile={bpmnStringFile}
+        modelerInnerHeight={window.innerHeight}
+        elementClassesToRemove={elementClassesToRemove}
+        padEntriesToRemove={padEntriesToRemove}
+        onElementChange={(xml: string): void => alert(xml)}
+        onTaskTarget={(event: CustomEvent): void => alert(JSON.stringify(event.detail))}
+        onTaskLabelTarget={(event: CustomEvent): void => {
         // Set an element programmatically
         const modeling = modelerRef?.current?.get('modeling')
         const elementRegistry = modelerRef?.current?.get('elementRegistry')
         const element = elementRegistry.get(event.detail.id)
         modeling.updateProperties(element, { name: 'Example task label' })
       }}
-      onError={(error: Error): void => alert(error)}
-    />
+        onError={(error: Error): void => alert(error)}
+      />
+    ),
+    [bpmnStringFile]
   )
 
-  return (
-    <Fragment>{bpmnModelerRef.current}</Fragment>
-  )
+  useEffect(() => {
+    setBpmnStringFile(getBpmnFile())
+  }, [setBpmnStringFile])
+
+  useEffect(() => {
+    if (bpmnStringFile && !model) {
+      setModel(setModeler)
+    }
+  }, [bpmnStringFile, model, setModeler])
+
+  return <Fragment>{model}</Fragment>
 }
 
 export default App
+
 ```
 
 With React
 
 ```jsx
 
-import React, { FC, useRef } from 'react'
+import React, { useRef, Fragment } from 'react'
 import { Bpmn } from '@arkondata/react-bpmn-modeler/lib/components'
 
-const App: FC = () => {
+//load bpmnStringFile from anywere
+const getBpmnFile = () => `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  id="Definitions_1"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+>
+  <bpmn:collaboration id="Collaboration_0nai2jf">
+    <bpmn:participant id="Participant_0n01i1w" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="Event_0sd8xgt" name="Start">
+      <bpmn:outgoing>Flow_094auwy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_02384jl" name="Example task label">
+      <bpmn:incoming>Flow_094auwy</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_094auwy" sourceRef="Event_0sd8xgt" targetRef="Activity_02384jl" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0nai2jf">
+      <bpmndi:BPMNShape id="Participant_0n01i1w_di" bpmnElement="Participant_0n01i1w" isHorizontal="true">
+        <dc:Bounds x="-400" y="-320" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_094auwy_di" bpmnElement="Flow_094auwy">
+        <di:waypoint x="-282" y="-210" />
+        <di:waypoint x="-230" y="-210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0sd8xgt_di" bpmnElement="Event_0sd8xgt">
+        <dc:Bounds x="-318" y="-228" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-312" y="-185" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02384jl_di" bpmnElement="Activity_02384jl">
+        <dc:Bounds x="-230" y="-250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`
+
+export const elementClassesToRemove = [
+  'bpmn-icon-subprocess-collapsed',
+  'bpmn-icon-subprocess-expanded',
+  'bpmn-icon-business-rule',
+  'bpmn-icon-service',
+  'bpmn-icon-start-event-condition',
+  'bpmn-icon-start-event-signal',
+  'bpmn-icon-data-object',
+  'bpmn-icon-data-store',
+]
+
+export const padEntriesToRemove = {
+  StartEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  IntermediateThrowEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  IntermediateCatchEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  EndEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  CallActivity: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  SubProcess: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Gateway: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  SequenceFlow: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  TextAnnotation: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Participant: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Lane: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  DataStoreReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  DataObjectReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  label: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Association: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Task: []
+}
+
+const App = () => {
   const modelerRef = useRef()
-  const bpmnModelerRef = useRef(
-    <Bpmn
-      modelerRef={modelerRef}
-      bpmnStringFile={''}
-      modelerInnerHeight={window.innerHeight}
-      onElementChange={xml => alert(xml)}
-      onTaskTarget={event => alert(JSON.stringify(event.detail))}
-      onTaskLabelTarget={event => {
+  const [model, setModel] = useState()
+  const [bpmnStringFile, setBpmnStringFile] = useState('')
+  const setModeler = useCallback(
+    () => (
+      <Bpmn
+        modelerRef={modelerRef}
+        bpmnStringFile={bpmnStringFile}
+        modelerInnerHeight={window.innerHeight}
+        elementClassesToRemove={elementClassesToRemove}
+        padEntriesToRemove={padEntriesToRemove}
+        onElementChange={xml => alert(xml)}
+        onTaskTarget={event => alert(JSON.stringify(event.detail))}
+        onTaskLabelTarget={event => {
         // Set an element programmatically
-        const modeling = modelerRef.current.get('modeling')
-        const elementRegistry = modelerRef.current.get('elementRegistry')
+        const modeling = modelerRef?.current?.get('modeling')
+        const elementRegistry = modelerRef?.current?.get('elementRegistry')
         const element = elementRegistry.get(event.detail.id)
         modeling.updateProperties(element, { name: 'Example task label' })
       }}
-      onError={error => alert(error)}
-    />
+        onError={error => alert(error)}
+      />
+    ),
+    [bpmnStringFile]
   )
 
-  return (
-    <Fragment>{bpmnModelerRef.current}</Fragment>
-  )
+  useEffect(() => {
+    setBpmnStringFile(getBpmnFile())
+  }, [setBpmnStringFile])
+
+  useEffect(() => {
+    if (bpmnStringFile && !model) {
+      setModel(setModeler)
+    }
+  }, [bpmnStringFile, model, setModeler])
+
+  return <Fragment>{model}</Fragment>
 }
 
 export default App
+
 ```
 
 ## Params ##
@@ -99,9 +285,13 @@ export default App
 
 * **zStep:** Number of zoom step of zoom in/out action button.
 
+* **elementClassesToRemove:** Item classes to remove from the item popup panel.
+
+* **padEntriesToRemove:** Item classes to remove from the item lateral pad.
+
 * **onElementChange:** A function that runs every time a bpmn modeler element changes, accepts as a parameter a variable that contains the exported file in a text string.
 
-* **onTaskTarget:** It is a function that is executed when you click on the gear icon in the side pad of a task element, it accepts a function that receives as event parameter of the selected element. **\***
+* **onTaskTarget:** It is a function that is executed when you click on the gear icon in the side pad of a task element, it accepts a function that receives as event parameter of the selected element.
 
 *event.detail* returns
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,21 +54,21 @@ export const elementClassesToRemove = [
 // Item classes to remove from the item lateral pad
 
 export const padEntriesToRemove: PadEntriesToRemoveType = {
-  StartEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  IntermediateThrowEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  IntermediateCatchEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  EndEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  CallActivity: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  SubProcess: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Gateway: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  SequenceFlow: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  TextAnnotation: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Participant: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Lane: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  DataStoreReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  DataObjectReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  label: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Association: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  StartEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  IntermediateThrowEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  IntermediateCatchEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  EndEvent: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  CallActivity: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  SubProcess: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Gateway: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  SequenceFlow: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  TextAnnotation: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Participant: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Lane: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  DataStoreReference: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  DataObjectReference: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  label: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
+  Association: ['bpmn-icon-custom-task-documentation', 'bpmn-icon-custom-task-settings'],
   Task: []
 }
 
@@ -86,11 +86,13 @@ const App: FC = () => {
         padEntriesToRemove={padEntriesToRemove}
         onElementChange={(xml: string): void => alert(xml)}
         onTaskTarget={(event: CustomEvent): void => alert(JSON.stringify(event.detail))}
-        onTaskLabelTarget={(event: CustomEvent): void => {
-          const modeling = modelerRef?.current?.get('modeling')
+        onTaskDocumentationTarget={(event: CustomEvent): void => {
           const elementRegistry = modelerRef?.current?.get('elementRegistry')
+          const modeling = modelerRef?.current?.get('modeling')
+          const moddle = modelerRef?.current?.get('moddle')
           const element = elementRegistry.get(event.detail.id)
-          modeling.updateProperties(element, { name: 'Example task label' })
+          const documentation = moddle.create('bpmn:Documentation', { text: 'Documenation text' })
+          modeling.updateProperties(element, { documentation: [documentation] })
         }}
         onError={(error: Error): void => alert(error)}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useRef, Fragment, useState, useCallback, useEffect } from 'react'
 import Bpmn, { BpmnModelerType } from './components/Bpmn'
+import { PadEntriesToRemoveType } from './components/Bpmn/types'
 
 //load bpmnStringFile from anywere
 const getBpmnFile = (): string => `<?xml version="1.0" encoding="UTF-8"?>
@@ -38,6 +39,39 @@ const getBpmnFile = (): string => `<?xml version="1.0" encoding="UTF-8"?>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>`
 
+// Item classes to remove from the item popup panel
+export const elementClassesToRemove = [
+  'bpmn-icon-subprocess-collapsed',
+  'bpmn-icon-subprocess-expanded',
+  'bpmn-icon-business-rule',
+  'bpmn-icon-service',
+  'bpmn-icon-start-event-condition',
+  'bpmn-icon-start-event-signal',
+  'bpmn-icon-data-object',
+  'bpmn-icon-data-store'
+]
+
+// Item classes to remove from the item lateral pad
+
+export const padEntriesToRemove: PadEntriesToRemoveType = {
+  StartEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  IntermediateThrowEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  IntermediateCatchEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  EndEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  CallActivity: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  SubProcess: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Gateway: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  SequenceFlow: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  TextAnnotation: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Participant: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Lane: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  DataStoreReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  DataObjectReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  label: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Association: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Task: []
+}
+
 const App: FC = () => {
   const modelerRef = useRef<BpmnModelerType>()
   const [model, setModel] = useState<JSX.Element>()
@@ -48,6 +82,8 @@ const App: FC = () => {
         modelerRef={modelerRef}
         bpmnStringFile={bpmnStringFile}
         modelerInnerHeight={window.innerHeight}
+        elementClassesToRemove={elementClassesToRemove}
+        padEntriesToRemove={padEntriesToRemove}
         onElementChange={(xml: string): void => alert(xml)}
         onTaskTarget={(event: CustomEvent): void => alert(JSON.stringify(event.detail))}
         onTaskLabelTarget={(event: CustomEvent): void => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,78 @@
-import React, { FC, useRef, MutableRefObject, Fragment } from 'react'
+import React, { FC, useRef, Fragment, useState, useCallback, useEffect } from 'react'
 import Bpmn, { BpmnModelerType } from './components/Bpmn'
 
+//load bpmnStringFile from anywere
+const getBpmnFile = (): string => `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:collaboration id="Collaboration_0nai2jf">
+    <bpmn:participant id="Participant_0n01i1w" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="Event_0sd8xgt" name="Start">
+      <bpmn:outgoing>Flow_094auwy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_02384jl" name="Example task label">
+      <bpmn:incoming>Flow_094auwy</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_094auwy" sourceRef="Event_0sd8xgt" targetRef="Activity_02384jl" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0nai2jf">
+      <bpmndi:BPMNShape id="Participant_0n01i1w_di" bpmnElement="Participant_0n01i1w" isHorizontal="true">
+        <dc:Bounds x="-400" y="-320" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_094auwy_di" bpmnElement="Flow_094auwy">
+        <di:waypoint x="-282" y="-210" />
+        <di:waypoint x="-230" y="-210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0sd8xgt_di" bpmnElement="Event_0sd8xgt">
+        <dc:Bounds x="-318" y="-228" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-312" y="-185" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02384jl_di" bpmnElement="Activity_02384jl">
+        <dc:Bounds x="-230" y="-250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`
+
 const App: FC = () => {
-  const modelerRef: MutableRefObject<BpmnModelerType | undefined> = useRef()
-  const bpmnModelerRef: MutableRefObject<JSX.Element> = useRef(
-    <Bpmn
-      modelerRef={modelerRef}
-      bpmnStringFile={''}
-      modelerInnerHeight={window.innerHeight}
-      onElementChange={(xml: string): void => alert(xml)}
-      onTaskTarget={(event: CustomEvent): void => alert(JSON.stringify(event.detail))}
-      onTaskLabelTarget={(event: CustomEvent): void => {
-        const modeling = modelerRef?.current?.get('modeling')
-        const elementRegistry = modelerRef?.current?.get('elementRegistry')
-        const element = elementRegistry.get(event.detail.id)
-        modeling.updateProperties(element, { name: 'Example task label' })
-      }}
-      onError={(error: Error): void => alert(error)}
-    />
+  const modelerRef = useRef<BpmnModelerType>()
+  const [model, setModel] = useState<JSX.Element>()
+  const [bpmnStringFile, setBpmnStringFile] = useState('')
+  const setModeler = useCallback(
+    (): JSX.Element => (
+      <Bpmn
+        modelerRef={modelerRef}
+        bpmnStringFile={bpmnStringFile}
+        modelerInnerHeight={window.innerHeight}
+        onElementChange={(xml: string): void => alert(xml)}
+        onTaskTarget={(event: CustomEvent): void => alert(JSON.stringify(event.detail))}
+        onTaskLabelTarget={(event: CustomEvent): void => {
+          const modeling = modelerRef?.current?.get('modeling')
+          const elementRegistry = modelerRef?.current?.get('elementRegistry')
+          const element = elementRegistry.get(event.detail.id)
+          modeling.updateProperties(element, { name: 'Example task label' })
+        }}
+        onError={(error: Error): void => alert(error)}
+      />
+    ),
+    [bpmnStringFile]
   )
 
-  return <Fragment>{bpmnModelerRef.current}</Fragment>
+  useEffect(() => {
+    setBpmnStringFile(getBpmnFile())
+  }, [setBpmnStringFile])
+
+  useEffect(() => {
+    if (bpmnStringFile && !model) {
+      setModel(setModeler)
+    }
+  }, [bpmnStringFile, model, setModeler])
+
+  return <Fragment>{model}</Fragment>
 }
 
 export default App

--- a/src/bpmn-font/css/bpmn.css
+++ b/src/bpmn-font/css/bpmn.css
@@ -51,7 +51,7 @@
 }
 
 /* '' */
-.bpmn-icon-custom-task-label:before {
+.bpmn-icon-custom-task-documentation:before {
   content: '\e873';
 }
 

--- a/src/components/Bpmn/Bpmn.tsx
+++ b/src/components/Bpmn/Bpmn.tsx
@@ -65,6 +65,8 @@ const Bpmn: FC<BpmnType> = ({
   }
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  // Custom pad entries
   const memorizeImportXML = useCallback((): void => {
     modelerRef?.current?.importXML(
       bpmnStringFile ? bpmnStringFile : newBpmnDiagram,
@@ -99,7 +101,7 @@ const Bpmn: FC<BpmnType> = ({
     )
   }, [modelerRef, onElementChange, onError])
 
-  const bpmnPadCustomButtonEventBus = useCallback((): void => {
+  const handleEventBus = useCallback((): void => {
     type eventBusType = { current: { element: { type: string } } }
     const eventBus = modelerRef?.current?.get('eventBus')
     eventBus.on('elements.changed', (): void => {
@@ -116,6 +118,7 @@ const Bpmn: FC<BpmnType> = ({
       }
     )
   }, [modelerRef, removeCustomTaskEntry, saveModel])
+  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   const memorizeSetModeler = useCallback((): void => {
     modelerRef.current = new BpmnModeler({
@@ -133,8 +136,8 @@ const Bpmn: FC<BpmnType> = ({
       height: modelerInnerHeight ? modelerInnerHeight : window.innerHeight
     })
     memorizeImportXML()
-    bpmnPadCustomButtonEventBus()
-  }, [memorizeImportXML, modelerInnerHeight, bpmnPadCustomButtonEventBus, modelerRef])
+    handleEventBus()
+  }, [memorizeImportXML, modelerInnerHeight, handleEventBus, modelerRef])
 
   useEffect((): void => {
     memorizeSetModeler()

--- a/src/components/Bpmn/Bpmn.tsx
+++ b/src/components/Bpmn/Bpmn.tsx
@@ -12,6 +12,7 @@ import { newBpmnDiagram } from './default-bpmn-layout'
 import ActionButton from './ActionButton'
 
 import { BpmnType } from './types'
+import { findLateralPadEntries } from './utils'
 
 import '../../styles/index.css'
 import '../../bpmn-font/css/bpmn-embedded.css'
@@ -71,38 +72,13 @@ const Bpmn: FC<BpmnType> = ({
     )
   }, [onError, bpmnStringFile, modelerRef, fitViewport])
 
-  const removeCustomIcon = (divGroupIndex: number): void => {
-    const groups = document.querySelectorAll('.group')
-    const group = groups[divGroupIndex]
-    if (group.lastChild) {
-      group.lastChild.remove()
-      group.lastChild.remove()
-    }
-  }
+  const removeCustomTaskEntry = useCallback((type: string) => {
+    const lateralPadEntries: Element[] = findLateralPadEntries(type)
 
-  const removeCustomTaskButton = useCallback((type: string) => {
-    type bpmnElementPadDivType = {
-      [key: string]: number
-    }
-    const bpmnElementPadDiv: bpmnElementPadDivType = {
-      StartEvent: 1,
-      IntermediateThrowEvent: 1,
-      IntermediateCatchEvent: 1,
-      EndEvent: 0,
-      CallActivity: 1,
-      SubProcess: 1,
-      Gateway: 1,
-      SequenceFlow: 0,
-      TextAnnotation: 0,
-      Participant: 3,
-      DataStoreReference: 2,
-      DataObjectReference: 2
-    }
-    for (const key in bpmnElementPadDiv) {
-      if (type.includes(key)) {
-        const divGroupIndex: number = bpmnElementPadDiv[key]
-        removeCustomIcon(divGroupIndex)
-      }
+    if (lateralPadEntries.length > 0) {
+      lateralPadEntries.forEach((element: Element) => {
+        element.parentNode?.removeChild(element)
+      })
     }
   }, [])
 
@@ -136,10 +112,10 @@ const Bpmn: FC<BpmnType> = ({
           element: { type }
         }
       }: eventBusType): void => {
-        removeCustomTaskButton(type)
+        removeCustomTaskEntry(type)
       }
     )
-  }, [modelerRef, removeCustomTaskButton, saveModel])
+  }, [modelerRef, removeCustomTaskEntry, saveModel])
 
   const memorizeSetModeler = useCallback((): void => {
     modelerRef.current = new BpmnModeler({

--- a/src/components/Bpmn/Bpmn.tsx
+++ b/src/components/Bpmn/Bpmn.tsx
@@ -7,7 +7,10 @@ import minimapModule from 'diagram-js-minimap'
 import camundaModdleDescriptor from 'camunda-bpmn-moddle/resources/camunda'
 
 import { i18nSpanish } from './translations'
-import CustomControlsModule, { TASK_SETTINGS_EVENT, TASK_LABEL_EVENT } from './CustomControlsModule'
+import CustomControlsModule, {
+  TASK_SETTINGS_EVENT,
+  TASK_DOCUMENTATION_EVENT
+} from './CustomControlsModule'
 import { newBpmnDiagram } from './default-bpmn-layout'
 import ActionButton from './ActionButton'
 
@@ -45,7 +48,7 @@ const Bpmn: FC<BpmnType> = ({
   padEntriesToRemove,
   onElementChange,
   onTaskTarget,
-  onTaskLabelTarget,
+  onTaskDocumentationTarget,
   onError,
   children
 }) => {
@@ -162,11 +165,11 @@ const Bpmn: FC<BpmnType> = ({
 
   useEffect((): void => {
     document.addEventListener(
-      TASK_LABEL_EVENT,
-      (event: Event): void => onTaskLabelTarget?.(event),
+      TASK_DOCUMENTATION_EVENT,
+      (event: Event): void => onTaskDocumentationTarget?.(event),
       false
     )
-  }, [onTaskLabelTarget])
+  }, [onTaskDocumentationTarget])
 
   return (
     <Fullscreen

--- a/src/components/Bpmn/CustomControlsModule/CustomContextPad.ts
+++ b/src/components/Bpmn/CustomControlsModule/CustomContextPad.ts
@@ -1,6 +1,6 @@
 import {
   TASK_SETTINGS_EVENT,
-  TASK_LABEL_EVENT,
+  TASK_DOCUMENTATION_EVENT,
   getContextPadEntriesType,
   ContextPadEntriesType
 } from './types'
@@ -38,7 +38,7 @@ class CustomContextPad {
     }
 
     const taskLabel = (): void => {
-      const customEvent = new CustomEvent(TASK_LABEL_EVENT, {
+      const customEvent = new CustomEvent(TASK_DOCUMENTATION_EVENT, {
         detail: {
           id: element.businessObject.id,
           $type: element.businessObject.$type,
@@ -61,10 +61,10 @@ class CustomContextPad {
           click: taskSettings
         }
       },
-      'task-label': {
+      'task-documentation': {
         group: 'edit',
-        className: 'bpmn-icon-custom-task-label',
-        title: this.translate('Task label'),
+        className: 'bpmn-icon-custom-task-documentation',
+        title: this.translate('Task documentation'),
         action: {
           click: taskLabel
         }

--- a/src/components/Bpmn/CustomControlsModule/index.ts
+++ b/src/components/Bpmn/CustomControlsModule/index.ts
@@ -1,7 +1,7 @@
 import CustomContextPad from './CustomContextPad'
 import CustomPalette from './CustomPalette'
 
-export { TASK_SETTINGS_EVENT, TASK_LABEL_EVENT } from './types'
+export { TASK_SETTINGS_EVENT, TASK_DOCUMENTATION_EVENT } from './types'
 
 export default {
   __init__: ['customContextPad', 'customPalette'],

--- a/src/components/Bpmn/CustomControlsModule/types.ts
+++ b/src/components/Bpmn/CustomControlsModule/types.ts
@@ -1,5 +1,5 @@
 export const TASK_SETTINGS_EVENT = 'TASK_SETTINGS_EVENT'
-export const TASK_LABEL_EVENT = 'TASK_LABEL_EVENT'
+export const TASK_DOCUMENTATION_EVENT = 'TASK_DOCUMENTATION_EVENT'
 
 export type ContextPadEntriesType = {
   businessObject: {
@@ -22,7 +22,7 @@ export type getContextPadEntriesType = {
       click: () => void
     }
   }
-  'task-label': {
+  'task-documentation': {
     group: string
     className: string
     title: string

--- a/src/components/Bpmn/translations/i18n/Spanish.ts
+++ b/src/components/Bpmn/translations/i18n/Spanish.ts
@@ -75,7 +75,7 @@ const i18nSpanish: Record<string, string> = {
   'Change type': 'Cambiar tipo',
   Remove: 'Eliminar',
   TextAnnotation: 'Anotación de texto',
-  'Task label': 'Etiqueta de tarea',
+  'Task documentation': 'Documentatión de tarea',
 
   // Errors
   'no parent for {element} in {parent}': 'Sin padre para {element} en {parent}',

--- a/src/components/Bpmn/types.ts
+++ b/src/components/Bpmn/types.ts
@@ -21,6 +21,6 @@ export type BpmnType = {
   padEntriesToRemove?: PadEntriesToRemoveType
   onElementChange?: (xml: string) => void
   onTaskTarget?: Function
-  onTaskLabelTarget?: Function
+  onTaskDocumentationTarget?: Function
   onError: (error: Error) => void
 }

--- a/src/components/Bpmn/types.ts
+++ b/src/components/Bpmn/types.ts
@@ -18,3 +18,7 @@ export type BpmnType = {
   onTaskLabelTarget: Function
   onError: (error: Error) => void
 }
+
+export type ElementCustomPadEntriesType = {
+  [key: string]: string[]
+}

--- a/src/components/Bpmn/types.ts
+++ b/src/components/Bpmn/types.ts
@@ -7,18 +7,20 @@ export type BpmnModelerType = {
   saveXML: Function
 }
 
+export type PadEntriesToRemoveType = {
+  [key: string]: string[]
+}
+
 export type BpmnType = {
   modelerRef: MutableRefObject<BpmnModelerType | undefined>
   bpmnStringFile: string | ArrayBuffer | false | null | undefined
   modelerInnerHeight?: number
   actionButtonClassName?: string
   zStep?: number
+  elementClassesToRemove?: string[]
+  padEntriesToRemove?: PadEntriesToRemoveType
   onElementChange?: (xml: string) => void
-  onTaskTarget: Function
-  onTaskLabelTarget: Function
+  onTaskTarget?: Function
+  onTaskLabelTarget?: Function
   onError: (error: Error) => void
-}
-
-export type ElementCustomPadEntriesType = {
-  [key: string]: string[]
 }

--- a/src/components/Bpmn/utils.ts
+++ b/src/components/Bpmn/utils.ts
@@ -1,0 +1,38 @@
+import { ElementCustomPadEntriesType } from './types'
+
+const entriesToRemove: ElementCustomPadEntriesType = {
+  StartEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  IntermediateThrowEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  IntermediateCatchEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  EndEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  CallActivity: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  SubProcess: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Gateway: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  SequenceFlow: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  TextAnnotation: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Participant: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  DataStoreReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  DataObjectReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Task: []
+}
+
+const getElements = (elementClasses: string[]): Element[] => {
+  let elements: Element[] = []
+
+  elementClasses.forEach((elementClass: string) => {
+    const element = document.getElementsByClassName(elementClass)
+    elements = [...elements, ...element]
+  })
+
+  return elements
+}
+
+export const findLateralPadEntries = (type: string): Element[] => {
+  for (const [key, lateralPadEntryClasses] of Object.entries(entriesToRemove)) {
+    if (type.includes(key) && lateralPadEntryClasses.length > 0) {
+      return getElements(lateralPadEntryClasses)
+    }
+  }
+
+  return []
+}

--- a/src/components/Bpmn/utils.ts
+++ b/src/components/Bpmn/utils.ts
@@ -1,21 +1,4 @@
-import { ElementCustomPadEntriesType } from './types'
-
-const entriesToRemove: ElementCustomPadEntriesType = {
-  StartEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  IntermediateThrowEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  IntermediateCatchEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  EndEvent: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  CallActivity: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  SubProcess: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Gateway: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  SequenceFlow: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  TextAnnotation: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Participant: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Lane: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  DataStoreReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  DataObjectReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
-  Task: []
-}
+import { PadEntriesToRemoveType } from './types'
 
 const getElements = (elementClasses: string[]): Element[] => {
   let elements: Element[] = []
@@ -28,12 +11,30 @@ const getElements = (elementClasses: string[]): Element[] => {
   return elements
 }
 
-export const findLateralPadEntries = (type: string): Element[] => {
-  for (const [key, lateralPadEntryClasses] of Object.entries(entriesToRemove)) {
-    if (type.includes(key) && lateralPadEntryClasses.length > 0) {
-      return getElements(lateralPadEntryClasses)
+export const findLateralPadEntries = (
+  type: string,
+  entriesToRemove?: PadEntriesToRemoveType
+): Element[] => {
+  if (entriesToRemove) {
+    for (const [key, lateralPadEntryClasses] of Object.entries(entriesToRemove)) {
+      if (type.includes(key) && lateralPadEntryClasses.length > 0) {
+        return getElements(lateralPadEntryClasses)
+      }
     }
   }
 
   return []
+}
+
+export const removeElementsByClass = (classToRemove?: string[]): void => {
+  let elements: Element[] = []
+  if (!classToRemove) {
+    return
+  }
+  elements = getElements(classToRemove)
+  if (elements.length > 0) {
+    elements.forEach((element: Element): void => {
+      element.remove()
+    })
+  }
 }

--- a/src/components/Bpmn/utils.ts
+++ b/src/components/Bpmn/utils.ts
@@ -11,6 +11,7 @@ const entriesToRemove: ElementCustomPadEntriesType = {
   SequenceFlow: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
   TextAnnotation: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
   Participant: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
+  Lane: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
   DataStoreReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
   DataObjectReference: ['bpmn-icon-custom-task-label', 'bpmn-icon-custom-task-settings'],
   Task: []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Agregar elemento documentation desde la referencia del modelador
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here -->

Resolves [#8acmyp ] <!-- and resolves #... id ClickUp Task -->

## Description
Se modifica la funcionalidad de modificar la etiqueta del elemento task por agregar un elemento "connfiguration" con su respectivo texto
<!--- Describe your changes in detail -->
Se activa al dar click en el ícono de documento en el pad lateral del elemento Task.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe how to test your changes. -->

<!-- ## Screenshots (if appropriate): -->

<!-- Types of changes -->
<!-- Add labels that describe the kind of changes that your code introduce-->
<!-- Like: bugfix, feature, etc. -->
